### PR TITLE
Add missing await to chmod execution

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -61,7 +61,7 @@ async function run() {
 
     // Set mode
 
-    exec.exec('chmod', ['+x', ormolu_cached_path], {silent: true});
+    await exec.exec('chmod', ['+x', ormolu_cached_path], {silent: true});
 
     // Glob for the files to format
 

--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ async function run() {
 
     // Set mode
 
-    exec.exec('chmod', ['+x', ormolu_cached_path], {silent: true});
+    await exec.exec('chmod', ['+x', ormolu_cached_path], {silent: true});
 
     // Glob for the files to format
 


### PR DESCRIPTION
I recently ran into an issue with `fourmolu-action` (https://github.com/fourmolu/fourmolu-action/pull/7) where a missing `await` caused `fourmolu` to not be executable when called. I haven't tried to recreate this with `ormolu-action`, but as `fourmolu-action` is a close fork I believe it would have the same issue. I thought I'd therefore open the same PR to `ormolu-action`.