### PR TITLE
Add version input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+* Added the `version` input which allows the user to select the Ormolu
+  version explicitly. It defaults to the latest version known.
+
 ## Ormolu action v10
 
 * Uses Ormolu 0.5.3.0.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ and its formatted version.
   (default: true).
 * `follow-symbolic-links` Whether to follow symbolic links (default: true).
 * `extra-args` Extra arguments to pass to Ormolu.
+* `version` The version number of Ormolu to use. Defaults to `"latest"`.
 
 ## Windows
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,11 @@ inputs:
     required: false
     description: >
       Extra arguments to pass to Ormolu.
+  version:
+    required: false
+    description: >
+      The version number of Ormolu to use. Defaults to "latest".
+    default: latest
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -17,7 +17,8 @@ const tool_cache = __webpack_require__(7784);
 const exec = __webpack_require__(1514);
 const glob = __webpack_require__(8090);
 
-const ormolu_version = '0.5.3.0';
+const input_version = core.getInput('version');
+const ormolu_version = input_version === 'latest' ? '0.5.3.0' : input_version;
 const ormolu_linux_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Linux.zip';
 const ormolu_windows_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Windows.zip';
 const ormolu_macos_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-macOS.zip';

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const tool_cache = require('@actions/tool-cache');
 const exec = require('@actions/exec');
 const glob = require('@actions/glob');
 
-const ormolu_version = '0.5.3.0';
+const input_version = core.getInput('version');
+const ormolu_version = input_version === 'latest' ? '0.5.3.0' : input_version;
 const ormolu_linux_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Linux.zip';
 const ormolu_windows_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-Windows.zip';
 const ormolu_macos_url = 'https://github.com/tweag/ormolu/releases/download/' + ormolu_version + '/ormolu-macOS.zip';


### PR DESCRIPTION
This allows setting Ormolu's version number using an input to the action. For example:

``` yaml
- uses: mrkkrp/ormolu-action@v10
  with:
    version: 0.5.3.0
```

The default value is "latest", which can be updated behind the scenes as new versions of Ormolu are released. If users want to use an older version of Ormolu with a newer version of this action, the `version` input lets them do that. 