### PR TITLE
add "mode" input

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ and its formatted version.
   account their `default-extensions` and `default-language` settings
   (default: true).
 * `follow-symbolic-links` Whether to follow symbolic links (default: true).
+* `mode` Specifies whether to simply 'check' files for formatting, or modify
+  the files 'inplace'.
 * `extra-args` Extra arguments to pass to Ormolu.
 * `version` The version number of Ormolu to use. Defaults to `"latest"`.
 

--- a/README.md
+++ b/README.md
@@ -63,3 +63,21 @@ passes.
 [ormolu]: https://github.com/tweag/ormolu
 [multiple-patterns-example]: https://github.com/haskell-actions/run-ormolu/blob/master/action.yml#L9-L11
 [git-core-autocrlf]: https://www.git-scm.com/docs/git-config#Documentation/git-config.txt-coreautocrlf
+
+## Example which commits the formatted files:
+
+```yaml
+jobs:
+  ormolu:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: haskell-actions/run-ormolu@v14
+        with:
+          mode: inplace
+      - name: apply formatting changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        if: ${{ always() }}
+        with:
+          commit_message: automated ormolu commit
+```

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,11 @@ inputs:
     description: >
       Whether to follow symbolic links.
     default: true
+  mode:
+    required: false
+    description: >
+      Mode of operation: 'stdout', 'inplace', or 'check' (the default).
+    default: 'check'
   extra-args:
     required: false
     description: >

--- a/dist/index.js
+++ b/dist/index.js
@@ -26,6 +26,7 @@ const ormolu_macos_url = 'https://github.com/tweag/ormolu/releases/download/' + 
 const input_pattern = core.getInput('pattern');
 const input_respect_cabal_files = core.getInput('respect-cabal-files').toUpperCase() !== 'FALSE';
 const input_follow_symbolic_links = core.getInput('follow-symbolic-links').toUpperCase() !== 'FALSE';
+const input_mode = core.getInput('mode').toLowerCase();
 const input_extra_args = core.getInput('extra-args');
 
 async function run() {
@@ -97,7 +98,7 @@ async function run() {
     if (files.length > 0) {
         await exec.exec(
             ormolu_cached_path,
-            ['--color', 'always', '--check-idempotence', '--mode', 'check']
+            ['--color', 'always', '--check-idempotence', '--mode', input_mode]
                 .concat(respect_cabal_files)
                 .concat(extra_args)
                 .concat(files)

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ const ormolu_macos_url = 'https://github.com/tweag/ormolu/releases/download/' + 
 const input_pattern = core.getInput('pattern');
 const input_respect_cabal_files = core.getInput('respect-cabal-files').toUpperCase() !== 'FALSE';
 const input_follow_symbolic_links = core.getInput('follow-symbolic-links').toUpperCase() !== 'FALSE';
+const input_mode = core.getInput('mode').toLowerCase();
 const input_extra_args = core.getInput('extra-args');
 
 async function run() {
@@ -86,7 +87,7 @@ async function run() {
     if (files.length > 0) {
         await exec.exec(
             ormolu_cached_path,
-            ['--color', 'always', '--check-idempotence', '--mode', 'check']
+            ['--color', 'always', '--check-idempotence', '--mode', input_mode]
                 .concat(respect_cabal_files)
                 .concat(extra_args)
                 .concat(files)


### PR DESCRIPTION
Adding the `mode` input lets me change `ormolu` to `inplace` mode, which allows me to automatically format and commit my PRs instead of kicking them back to the contributor and making them figure out how to use ormolu 😅 .

It's split into multiple commits for cherry-picking.